### PR TITLE
send Vary: Origin for non-CORS requests

### DIFF
--- a/src/quart_cors/__init__.py
+++ b/src/quart_cors/__init__.py
@@ -346,8 +346,8 @@ def _apply_cors(
             response.access_control_allow_methods = allow_methods
             if max_age is not None:
                 response.access_control_max_age = max_age
-        if "*" not in origin:
-            response.vary.add("Origin")
+    if origin is None or "*" not in origin:
+        response.vary.add("Origin")
     setattr(response, "_QUART_CORS_APPLIED", True)
     return response
 

--- a/src/quart_cors/__init__.py
+++ b/src/quart_cors/__init__.py
@@ -85,16 +85,6 @@ def route_cors(
             response created by Quart will be overwriten by one
             created by Quart-CORS.
 
-        send_wildcard: If set the allow origin response header is
-            replaced with a wildcard rather than the actual
-            origin. Requires the origins argument to also be '*'.
-        vary_header: If set the Vary header will include Origin,
-            allowing caching services to understand when to cache the
-        always_send: Always send the access control headers on
-            response, including when the request is missing an origin
-            header.
-            headers.
-
     """
 
     def decorator(func: Callable[P, ResponseReturnValue]) -> Callable[P, Awaitable[Response]]:


### PR DESCRIPTION
The Vary header should be sent when no Origin header is present.

The reason is [this issue](https://blog.keul.it/chrome-cors-issue-due-to-cache/) which afaik happens only with Chromium so far. It is also described in [the fetch spec](https://fetch.spec.whatwg.org/#cors-protocol-and-http-caches).

To sum up, imagine you have a page where you display an image using an `img` tag and a button to download it using `fetch`. The image will be displayed correctly but cached with no CORS headers. The second request will fail because the browser will attempt to get the image from the cache.