### PR TITLE
Added support in the decorator @route_cors for send_wildcard parameter

### DIFF
--- a/src/quart_cors/__init__.py
+++ b/src/quart_cors/__init__.py
@@ -85,6 +85,8 @@ def route_cors(
         provide_automatic_options: If set the automatic OPTIONS
             response created by Quart will be overwriten by one
             created by Quart-CORS.
+        send_wildcard: If set to False, Access-Control-Allow-Origin
+            will echo the request's Origin header instead of returning '*'
 
     """
 


### PR DESCRIPTION
I propose to add a send_wildcard parameter to the _@route_cors()_ decorator. The Flask-Cors decorator _@cross_origin()_ has this. The parameter's value can be True or False. 

If set to _True_, a wildcard Access-Control-Allow-Origin header is sent.

If set to _False_, the Access-Control-Allow-Origin header will echo the request's _Origin_ header.

The default value is _True_, so if this parameter is omitted, Quart-Cors will work precisely as it has done until now.