### PR TITLE
Add `cors_exempt` to `__all__` and add example for it

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,8 @@ strings or fragments) i.e. ``https://quart.com`` not
 ``https://quart.com/``.
 
 The ``cors_exempt`` decorator can be used in conjunction with ``cors``
-to exempt a websocket handler or view function from cors.
+to exempt a websocket handler or view function from cors. You can find
+a usage example in "Simple examples" section down below.
 
 Simple examples
 ~~~~~~~~~~~~~~~
@@ -192,6 +193,15 @@ the domain itself) of ``quart.com``,
 
     @app.websocket('/')
     @websocket_cors(allow_origin=re.compile(r"https:\/\/.*\.quart\.com"))
+    async def handler():
+        ...
+
+To exempt a WebSocket handler from CORS,
+
+.. code-block:: python
+
+    @app.websocket('/')
+    @cors_exempt
     async def handler():
         ...
 

--- a/src/quart_cors/__init__.py
+++ b/src/quart_cors/__init__.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     from typing_extensions import ParamSpec  # type: ignore
 
-__all__ = ("cors", "route_cors", "websocket_cors")
+__all__ = ("cors", "route_cors", "websocket_cors", "cors_exempt")
 
 OriginType = Union[Pattern, str]
 


### PR DESCRIPTION
In latest version of this package (0.7.0), when adding `cors_exempt` decorator to a WebSocket route, PyCharm gives this warning:

```
'cors_exempt' is not declared in __all__ 
```

This PR adds `cors_exempt` decorator function to `__all__`. Also, this PR adds a usage example in README for explaining newcomers how they can use this functionality more clearly.